### PR TITLE
fix: cap main-content width to match --content-width on desktop

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -434,6 +434,7 @@ a.sidebar-title-link:hover .site-name { text-decoration: underline; text-decorat
   .main-content {
     padding: 1.5rem 2rem;
     margin-left: 0;
+    max-width: var(--content-width);
   }
 }
 


### PR DESCRIPTION
Adds max-width: var(--content-width) so the content area is consistent with footer-inner (both 860px) and aligns with the layout design intent.